### PR TITLE
Implement respecting keywords

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/index/analysis/DecompoundTokenFilterFactory.java
+++ b/src/main/java/org/xbib/elasticsearch/index/analysis/DecompoundTokenFilterFactory.java
@@ -30,18 +30,21 @@ import org.elasticsearch.index.settings.IndexSettings;
 public class DecompoundTokenFilterFactory extends AbstractTokenFilterFactory {
 
     private final Decompounder decompounder;
+    private final Boolean respectKeywords;
 
     @Inject
     public DecompoundTokenFilterFactory(Index index,
             @IndexSettings Settings indexSettings, Environment env,
             @Assisted String name, @Assisted Settings settings) {
         super(index, indexSettings, name, settings);
+
         this.decompounder = createDecompounder(env, settings);
+        this.respectKeywords = settings.getAsBoolean("respect_keywords", false);
     }
 
     @Override
     public TokenStream create(TokenStream tokenStream) {
-        return new DecompoundTokenFilter(tokenStream, decompounder);
+        return new DecompoundTokenFilter(tokenStream, decompounder, respectKeywords);
     }
 
     private Decompounder createDecompounder(Environment env, Settings settings) {

--- a/src/test/resources/org/xbib/elasticsearch/index/analysis/keywords_analysis.json
+++ b/src/test/resources/org/xbib/elasticsearch/index/analysis/keywords_analysis.json
@@ -1,0 +1,62 @@
+{
+    "index": {
+        "analysis": {
+            "analyzer": {
+                "decompounding_default": {
+                    "tokenizer": "decomp",
+                    "filter": [
+                        "keywords",
+                        "decomp"
+                    ],
+                    "type": "custom"
+                },
+
+                "with_keywords": {
+                    "tokenizer": "decomp",
+                    "filter": [
+                        "keywords",
+                        "decomp_with_keywords"
+                    ],
+                    "type": "custom"
+                },
+
+                "with_keywords_disabled": {
+                    "tokenizer": "decomp",
+                    "filter": [
+                        "keywords",
+                        "decomp_with_keywords_disabled"
+                    ],
+                    "type": "custom"
+                }
+            },
+
+            "filter": {
+                "keywords": {
+                    "type": "keyword_marker",
+                    "keywords": [
+                        "Schlüsselwort"
+                    ]
+                },
+                "decomp": {
+                    "type": "decompound"
+                },
+                "decomp_with_keywords": {
+                    "type": "decompound",
+                    "respect_keywords": true
+                },
+                "decomp_with_keywords_disabled": {
+                    "type": "decompound",
+                    "respect_keywords": false
+                }
+            },
+
+            "tokenizer": {
+                "decomp": {
+                    "type": "standard",
+                    "filter": "decomp"
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Currently the `DecompoundTokenFilter` does not respect keywords that might come from any earlier 
[Keyword Marker Token Filter][1]. With this PR you can enable this behavior in the configuration by setting `"respect_keywords": true`. This will prevent the `DecompoundTokenFilter` from decompounding any keywords.

Please note that I set the default value for `respect_keywords` to false so this change is completely backwards compatible. also all changes are covered by tests.

[1]: https://www.elastic.co/guide/en/elasticsearch/reference/1.6/analysis-keyword-marker-tokenfilter.html
[2]: https://github.com/classmarkets/elasticsearch-analysis-decompound/blob/66f95aaf4494d80e474cfb33cdd65594002e1401/src/test/resources/org/xbib/elasticsearch/index/analysis/keywords_analysis.json#L45