### PR TITLE
Respect "and" operator from match query when using only_subwords

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/index/analysis/decompound/DecompoundTokenFilter.java
+++ b/src/main/java/org/xbib/elasticsearch/index/analysis/decompound/DecompoundTokenFilter.java
@@ -52,7 +52,8 @@ public class DecompoundTokenFilter extends TokenFilter {
             restoreState(current);
             termAtt.setEmpty().append(token.txt);
             offsetAtt.setOffset(token.startOffset, token.endOffset);
-            posIncAtt.setPositionIncrement(0);
+            if (!subwordsonly)
+                posIncAtt.setPositionIncrement(0);
             return true;
         }
         if (!input.incrementToken()) {


### PR DESCRIPTION
A match query with operator "and" involving a decompounded word (e.g. "viel kunststoff") was interpreted as "+viel +(kunst stoff)". This is most likely not the desired result, as "kunst" and "stoff" are not synonyms but both have to occur. This commit changes this behavior to be "+viel +kunst +stoff".

This solves issue #11.

This doesn't changes the behavior for `only_subwords: false` because the use case for that (and therefore the desired behavior) is unclear to me.